### PR TITLE
fix: stabilize macos build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-12]
 
     steps:
       - uses: actions/checkout@v5
@@ -31,7 +31,11 @@ jobs:
         run: |
           if [ -f tests/TestProject.lpi ]; then
             lazbuild tests/TestProject.lpi
-            ./tests/TestProject || exit 1
+            test_exec="./tests/TestProject"
+            if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+              test_exec="${test_exec}.exe"
+            fi
+            $test_exec || exit 1
           else
             echo "No tests found, skipping."
           fi
@@ -44,7 +48,11 @@ jobs:
           elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
             tar -czf Duhamel_integral-linux.tar.gz Duhamel_integral
           else
-            tar -czf Duhamel_integral-macos.tar.gz Duhamel_integral
+            if [ -d Duhamel_integral.app ]; then
+              tar -czf Duhamel_integral-macos.tar.gz Duhamel_integral.app
+            else
+              tar -czf Duhamel_integral-macos.tar.gz Duhamel_integral
+            fi
           fi
         shell: bash
 


### PR DESCRIPTION
## Summary
- build macOS on `macos-12` instead of latest to avoid incompatible Lazarus packages
- run Windows tests with the proper executable name
- package macOS binaries whether a `.app` bundle or raw binary

## Testing
- `yamllint .github/workflows/ci.yml` *(failed: command not found)*
- `pip install yamllint` *(failed: Could not find a version that satisfies the requirement yamllint; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c42927d7ec83229858746541edc42c