### PR TITLE
ci: use macos-latest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-12]
+        os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- use macOS latest runner in CI

## Testing
- `lazbuild Duhamel_integral.lpi` *(fails: command not found)*
- `yamllint .github/workflows/ci.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4305e1ff083228aa5b6ef25810519