### PR TITLE
chore: drop macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v5
@@ -41,20 +41,14 @@ jobs:
           fi
         shell: bash
 
-      - name: Package binary
-        run: |
-          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-            7z a Duhamel_integral-windows.zip Duhamel_integral.exe
-          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            tar -czf Duhamel_integral-linux.tar.gz Duhamel_integral
-          else
-            if [ -d Duhamel_integral.app ]; then
-              tar -czf Duhamel_integral-macos.tar.gz Duhamel_integral.app
+        - name: Package binary
+          run: |
+            if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+              7z a Duhamel_integral-windows.zip Duhamel_integral.exe
             else
-              tar -czf Duhamel_integral-macos.tar.gz Duhamel_integral
+              tar -czf Duhamel_integral-linux.tar.gz Duhamel_integral
             fi
-          fi
-        shell: bash
+          shell: bash
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@
 ### Linux
 [⬇️ Скачать Duhamel_integral-linux.tar.gz](https://github.com/andreyvrn/The-Duhamel-integral/releases/latest/download/Duhamel_integral-linux.tar.gz)
 
-### macOS
-[⬇️ Скачать Duhamel_integral-macos.tar.gz](https://github.com/andreyvrn/The-Duhamel-integral/releases/latest/download/Duhamel_integral-macos.tar.gz)
-
 ### Nightly build
 [⬇️ Скачать nightly](https://github.com/andreyvrn/The-Duhamel-integral/releases/tag/nightly)
 


### PR DESCRIPTION
## Summary
- remove macOS download instructions
- drop macOS from CI workflow

## Testing
- `lazbuild Duhamel_integral.lpi` *(fails: command not found)*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68c43cb07b288322bd2a4e7228e73f6b