### PR TITLE
Fix YAML indentation in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,14 @@ jobs:
           fi
         shell: bash
 
-        - name: Package binary
-          run: |
-            if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-              7z a Duhamel_integral-windows.zip Duhamel_integral.exe
-            else
-              tar -czf Duhamel_integral-linux.tar.gz Duhamel_integral
-            fi
-          shell: bash
+      - name: Package binary
+        run: |
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            7z a Duhamel_integral-windows.zip Duhamel_integral.exe
+          else
+            tar -czf Duhamel_integral-linux.tar.gz Duhamel_integral
+          fi
+        shell: bash
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- correct indentation for Package binary step in CI workflow
- ensure Upload Artifact step aligns with steps list

## Testing
- `ruby -r yaml -e 'YAML.load_file(".github/workflows/ci.yml")'`


------
https://chatgpt.com/codex/tasks/task_e_68c43e79c54483228336d369c3e6e48e