### PR TITLE
feat: add macos 13 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest, macos-13]
 
     steps:
       - uses: actions/checkout@v5
@@ -45,8 +45,10 @@ jobs:
         run: |
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
             7z a Duhamel_integral-windows.zip Duhamel_integral.exe
-          else
+          elif [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
             tar -czf Duhamel_integral-linux.tar.gz Duhamel_integral
+          else
+            tar -czf Duhamel_integral-macos.tar.gz Duhamel_integral
           fi
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 ### Linux
 [⬇️ Скачать Duhamel_integral-linux.tar.gz](https://github.com/andreyvrn/The-Duhamel-integral/releases/latest/download/Duhamel_integral-linux.tar.gz)
 
+### macOS
+[⬇️ Скачать Duhamel_integral-macos.tar.gz](https://github.com/andreyvrn/The-Duhamel-integral/releases/latest/download/Duhamel_integral-macos.tar.gz)
+
 ### Nightly build
 [⬇️ Скачать nightly](https://github.com/andreyvrn/The-Duhamel-integral/releases/tag/nightly)
 
@@ -26,3 +29,9 @@
 ### Windows
 ```powershell
 Duhamel_integral.exe
+```
+
+### macOS
+```bash
+./Duhamel_integral
+```


### PR DESCRIPTION
## Summary
- build on macOS 13 in CI
- package macOS binary and document usage

## Testing
- `lazbuild Duhamel_integral.lpi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4941bc2388322a826ce8372fe2808