### PR TITLE
Fix duplicate MainForm identifier causing Lazarus build failure

### DIFF
--- a/Duhamel_integral.lpi
+++ b/Duhamel_integral.lpi
@@ -47,7 +47,7 @@
         <ComponentName Value="MainForm"/>
         <HasResources Value="True"/>
         <ResourceBaseClass Value="Form"/>
-        <UnitName Value="MainForm"/>
+        <UnitName Value="MainFormUnit"/>
       </Unit1>
       <Unit2>
         <Filename Value="calculations.pas"/>

--- a/Duhamel_integral.lpr
+++ b/Duhamel_integral.lpr
@@ -7,7 +7,7 @@ uses
   cthreads,
   {$ENDIF}{$ENDIF}
   Interfaces, // this includes the LCL widgetset
-  Forms, tachartlazaruspkg, MainForm
+  Forms, tachartlazaruspkg, MainFormUnit
   { you can add units after this };
 
 {$R *.res}

--- a/calculations.pas
+++ b/calculations.pas
@@ -21,7 +21,6 @@ function Integral(upperBound, lowerBound: double; segments: word; Time: double):
 
 implementation
 
-uses Math;
 
 function InputSignal(Time: double): double;
 var

--- a/mainform.pas
+++ b/mainform.pas
@@ -1,4 +1,4 @@
-unit MainForm;
+unit MainFormUnit;
 
 {$mode objfpc}{$H+}
 


### PR DESCRIPTION
## Summary
- Rename main form unit to `MainFormUnit` and update project references to avoid naming conflict
- Remove unused Math unit from calculations

## Testing
- `fpc Duhamel_integral.lpr` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c548d33e1c832299f66de79dd2dead