### PR TITLE
Fix GitHub Actions matrix condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,14 @@ jobs:
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    if: github.event_name != 'pull_request' || matrix.os == 'ubuntu-latest'
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-13]
+        os: >-
+          ${{ fromJSON(
+              github.event_name == 'pull_request' &&
+              '["ubuntu-latest"]' ||
+              '["windows-latest","ubuntu-latest","macos-13"]'
+            ) }}
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- fix invalid matrix reference in CI workflow by using dynamic matrix expression

## Testing
- `yamllint .github/workflows/ci.yml`
- `lazbuild Duhamel_integral.lpi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c82beef890832297d0bc6ec59d8606